### PR TITLE
Updating the "Join" button link

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
 			<p>
 				A Slack community of designers, cultivators, artists, and creators from the Orlando area.
 			</p>
-			<a href="https://join.orlandodesigners.info/" class="button button--primary">
+			<a href="https://join.slack.com/t/orlandodesigners/shared_invite/zt-iywtgtvr-GV03BIgIdiize~r5s_uFxg" class="button button--primary">
 				Join The Community
 			</a>
 			<a href="https://orlandodesigners.slack.com" class=" button button__link link--invert">


### PR DESCRIPTION
@whosdustin I Updated the broken "Join" button link with a temporary link from https://orlandodesigners.slack.com/admin/shared_invites

Fix for: #5 